### PR TITLE
Remove unused `Redux` variable

### DIFF
--- a/freezer-redux-middleware.js
+++ b/freezer-redux-middleware.js
@@ -1,5 +1,3 @@
-var Redux = require('redux');
-
 var ActionTypes = {
 	INIT: '@@INIT',
 	PERFORM_ACTION: 'PERFORM_ACTION',


### PR DESCRIPTION
I installed the devtools, using the chrome extension method. However, the very first line of `freezer-redux-middleware` was:

``` js
var Redux = require('redux');
```

Making Redux required anyway. The variable was not used anywhere, so I just removed it.

Thanks for this handy extension and for `Freezer`!
