### PR TITLE
fix supportChromeExtension with redux devtools 1.0.0.17 (issue #5)

### DIFF
--- a/freezer-redux-middleware.js
+++ b/freezer-redux-middleware.js
@@ -93,7 +93,7 @@ function supportChromeExtension( State ){
 
 	compose(
 		FreezerMiddleware( State ),
-		window.devToolsExtension || function(f){ return f }
+		(window.devToolsExtension || function(f){ return f })()
 	)(createStore)( function( state ){
 		return state;
 	});


### PR DESCRIPTION
devToolsExtension() returns a mutator: function(next) {...} like
FreezerMiddle do. So we have to call it inside supportChromeExtension.
